### PR TITLE
Leaving quest now sets player area to zero.

### DIFF
--- a/src/SendCommands.cc
+++ b/src/SendCommands.cc
@@ -1869,9 +1869,7 @@ void send_resume_game(shared_ptr<Lobby> l, shared_ptr<Client> ready_client) {
 // player leaves quest
 void send_leave_quest(shared_ptr<Client> c) {
     static const be_uint32_t data = 0x73020000;
-    if (c->area > 0) {
-        c->area = 0;
-    }
+    c->area = 0;
     send_command(c, 0x60, 0x00, &data, sizeof(be_uint32_t));
 }
 

--- a/src/SendCommands.cc
+++ b/src/SendCommands.cc
@@ -1869,6 +1869,9 @@ void send_resume_game(shared_ptr<Lobby> l, shared_ptr<Client> ready_client) {
 // player leaves quest
 void send_leave_quest(shared_ptr<Client> c) {
     static const be_uint32_t data = 0x73020000;
+    if (c->area > 0) {
+        c->area = 0;
+    }
     send_command(c, 0x60, 0x00, &data, sizeof(be_uint32_t));
 }
 


### PR DESCRIPTION
A quick little fix that sets the character's area to zero when using $lobby.
It would break other commands such as $item due to the server sending the drops to the wrong area.